### PR TITLE
Add support for rulesetUrl

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ branding:
   color: "green"
 
 inputs:
+  custom-repolint-url:
+    description: "a url to a custom-repolint-file you wish to use"
+    required: false
   custom-repolint-file:
     description: "a path to a custom-repolint-file you wish to use"
     required: false
@@ -14,3 +17,4 @@ runs:
   image: "Dockerfile"
   env:
     CUSTOM_REPOLINT_FILE: ${{ inputs.custom-repolint-file }}
+    CUSTOM_REPOLINT_URL: ${{ inputs.custom-repolint-url }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,26 @@
 #!/bin/sh
 
+echo "::group::Setup Repolinter"
 set -euo
 
 echo "[INFO] Installing todogroup/repolinter"
 npm install -g log-symbols 
 npm install -g todogroup/repolinter 
 
-if [ -z "$CUSTOM_REPOLINT_FILE" ]; then
+if [ -n "$CUSTOM_REPOLINT_URL" ]; then
+  echo "[INFO] Insert CUSTOM configuration url"
+  REPOLINT_ARG="--rulesetUrl $CUSTOM_REPOLINT_URL"
+elif [ -n "$CUSTOM_REPOLINT_FILE" ]; then
+  echo "[INFO] Insert CUSTOM configuration file"
+  REPOLINT_ARG="--rulesetFile $CUSTOM_REPOLINT_FILE"
+else
   echo "[INFO] Insert default configuration"
   cp /repolinter/repolint.yml .
-  REPOLINT_FILE=repolint.yml
-else
-  echo "[INFO] Insert CUSTOM configuration"
-  REPOLINT_FILE=$CUSTOM_REPOLINT_FILE
+  REPOLINT_ARG="--rulesetFile repolint.yml"
 fi
 
 echo "[INFO] Executing:"
 echo "[INFO] repolinter $*"
-sh -c "repolinter --rulesetFile $REPOLINT_FILE $*"
+echo "::endgroup::"
+
+sh -c "repolinter $REPOLINT_ARG $*"


### PR DESCRIPTION
Add support for the `--rulesetURl` option, allowing repo definitions to be added from outside the repo.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>